### PR TITLE
ci: verify extension and kernel module builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - master
 
+env:
+  KERNEL_HEADERS_VERSION: 6.15.11-061511
+  KERNEL_HEADERS_DEB_VERSION: 6.15.11-061511.202508201748
+  KERNEL_HEADERS_URL: https://kernel.ubuntu.com/mainline/v6.15.11/amd64
+
 jobs:
   extension-build:
     runs-on: ubuntu-24.04
@@ -40,12 +45,19 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            bc build-essential dwarves libelf-dev linux-headers-generic xz-utils
+            bc build-essential curl dwarves libelf-dev xz-utils
+
+      - name: Install compatible kernel headers
+        run: |
+          curl -fsSLO "${KERNEL_HEADERS_URL}/linux-headers-${KERNEL_HEADERS_VERSION}_${KERNEL_HEADERS_DEB_VERSION}_all.deb"
+          curl -fsSLO "${KERNEL_HEADERS_URL}/linux-headers-${KERNEL_HEADERS_VERSION}-generic_${KERNEL_HEADERS_DEB_VERSION}_amd64.deb"
+          sudo apt-get install -y ./linux-headers-"${KERNEL_HEADERS_VERSION}"_"${KERNEL_HEADERS_DEB_VERSION}"_all.deb \
+            ./linux-headers-"${KERNEL_HEADERS_VERSION}"-generic_"${KERNEL_HEADERS_DEB_VERSION}"_amd64.deb
 
       - name: Resolve kernel headers
         id: kernel
         run: |
-          header_pkg="$(dpkg-query -W -f='${Package}\n' 'linux-headers-[0-9]*-generic' 2>/dev/null | sort -V | tail -n1)"
+          header_pkg="linux-headers-${KERNEL_HEADERS_VERSION}-generic"
           if [ -z "$header_pkg" ]; then
             echo "failed to resolve a linux-headers-*-generic package" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  extension-build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install extension build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential clang llvm \
+            libelf1 libelf-dev zlib1g-dev libclang-dev \
+            pkg-config
+
+      - name: Build extension
+        run: make build
+
+  kernel-module-build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install kernel module build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bc build-essential dwarves libelf-dev linux-headers-generic xz-utils
+
+      - name: Resolve kernel headers
+        id: kernel
+        run: |
+          header_pkg="$(dpkg-query -W -f='${Package}\n' 'linux-headers-[0-9]*-generic' 2>/dev/null | sort -V | tail -n1)"
+          if [ -z "$header_pkg" ]; then
+            echo "failed to resolve a linux-headers-*-generic package" >&2
+            exit 1
+          fi
+
+          syssrc="/usr/src/${header_pkg}"
+          if [ ! -d "$syssrc" ]; then
+            echo "kernel headers directory not found: $syssrc" >&2
+            exit 1
+          fi
+
+          echo "syssrc=$syssrc" >> "$GITHUB_OUTPUT"
+
+      - name: Build kernel module
+        run: make -C kernel-module/nvidia-module modules -j"$(nproc)" SYSSRC="${{ steps.kernel.outputs.syssrc }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: install deps
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
           libelf1 libelf-dev zlib1g-dev libclang-dev \
           make git clang llvm pkg-config build-essential

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,7 @@ jobs:
 
     - name: install deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
         libelf1 libelf-dev zlib1g-dev libclang-dev \
         make git clang llvm pkg-config build-essential
@@ -62,8 +63,6 @@ jobs:
       if:   github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: softprops/action-gh-release@v1
       with:
-          files: |
-            src/bootstrap
           prerelease: false
           tag_name: ${{ steps.set_version.outputs.result }}
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ make build    # Compiles all BPF policies + userspace loaders
 
 This builds libbpf and bpftool from submodules, then compiles each `.bpf.c` policy into BPF bytecode (`.bpf.o`) and a userspace loader binary. BPF objects and skeleton headers go to `extension/.output/`; loader binaries are placed directly in `extension/`.
 
+Some optional extension binaries require extra host dependencies:
+- `sched_gpu_*` needs `SCX_INCLUDE_DIR=/path/to/linux/tools/sched_ext/include`
+- `prefetch_adaptive_*` needs CUDA/NVML headers and stubs
+- `test_preempt_demo` / `test_preempt_multi` need CUDA driver headers and stubs
+
 ### 2. Build Kernel Module
 
 The modified NVIDIA kernel module (based on Open GPU Kernel Modules v575.57.08) adds BPF struct_ops hook points to `nvidia-uvm` for memory management and to `nvidia` for GPU scheduling.

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -14,22 +14,43 @@ ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
 			 | sed 's/arm.*/arm/' \
 			 | sed 's/riscv64/riscv/')
 VMLINUX := ../vmlinux/$(ARCH)/vmlinux.h
+CUDA_INCLUDE_DIR ?= /usr/local/cuda/include
+CUDA_STUB_DIR ?= /usr/local/cuda/lib64/stubs
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or
 # outdated
-INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi -I$(dir $(VMLINUX)) -I/usr/local/cuda/include
+INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi -I$(dir $(VMLINUX)) -I$(CUDA_INCLUDE_DIR)
 CFLAGS := -g -Wall
 ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
 
 # sched_ext (scx) headers for GPU-aware scheduler
-SCX_INCLUDE_DIR := $(HOME)/workspace/gpu/linux/tools/sched_ext/include
+SCX_INCLUDE_DIR ?=
+SCX_HEADER := $(if $(SCX_INCLUDE_DIR),$(SCX_INCLUDE_DIR)/scx/common.bpf.h,)
 SCX_VMLINUX := ../vmlinux/$(ARCH)/scx/vmlinux.h
-SCX_INCLUDES := -I$(SCX_INCLUDE_DIR) -I$(dir $(SCX_VMLINUX))
+SCX_INCLUDES := $(if $(SCX_INCLUDE_DIR),-I$(SCX_INCLUDE_DIR),) -I$(dir $(SCX_VMLINUX))
+HAVE_SCX := $(if $(SCX_INCLUDE_DIR),$(if $(wildcard $(SCX_HEADER)),$(if $(wildcard $(SCX_VMLINUX)),1,0),0),0)
+HAVE_NVML := $(if $(wildcard $(CUDA_INCLUDE_DIR)/nvml.h),$(if $(firstword $(wildcard $(CUDA_STUB_DIR)/libnvidia-ml.so $(CUDA_STUB_DIR)/libnvidia-ml.so.*)),1,0),0)
+HAVE_CUDA := $(if $(wildcard $(CUDA_INCLUDE_DIR)/cuda.h),$(if $(firstword $(wildcard $(CUDA_STUB_DIR)/libcuda.so $(CUDA_STUB_DIR)/libcuda.so.*)),1,0),0)
 
 BPF_APPS = struct_ops prefetch_always_max prefetch_none prefetch_adaptive_tree_iter prefetch_adaptive_sequential prefetch_pid_tree prefetch_eviction_pid prefetch_stride eviction_fifo eviction_lfu eviction_mru eviction_pid_quota eviction_freq_pid_decay eviction_fifo_chance eviction_cycle_moe chunk_trace prefetch_trace gpu_sched_trace gpu_preempt_ctrl gpu_sched_set_timeslices eviction_lfu_xcoord prefetch_always_max_cycle_moe prefetch_max_mru_expert prefetch_max_passive_mru prefetch_cross_block_v2 prefetch_template_belady prefetch_proactive_layer prefetch_always_max_xcoord prefetch_always_max_qos test_preempt_kfunc test_preempt_demo test_preempt_multi test_uprobe_preempt prefetch_faiss_phase prefetch_serving_adaptive # BPF apps that need skeletons
 SCX_APPS = sched_gpu_baseline sched_gpu_minimal sched_gpu_serving sched_gpu_xcoord sched_gpu_xcoord_noad sched_gpu_coord # sched_ext apps (need scx headers)
 TOOL_APPS = cleanup_struct_ops_tool # Pure userspace tools
-APPS = $(BPF_APPS) $(SCX_APPS) $(TOOL_APPS) # minimal minimal_legacy uprobe kprobe fentry usdt sockfilter tc ksyscall
+
+# Apps that need NVML
+NVML_APPS = prefetch_adaptive_tree_iter prefetch_adaptive_sequential
+
+# Apps that need pthread
+PTHREAD_APPS = gpu_preempt_ctrl
+
+# Apps that need CUDA driver API + pthread
+CUDA_APPS = test_preempt_demo test_preempt_multi
+
+CORE_BPF_APPS = $(filter-out $(NVML_APPS) $(CUDA_APPS),$(BPF_APPS))
+ENABLED_NVML_APPS = $(if $(filter 1,$(HAVE_NVML)),$(NVML_APPS),)
+ENABLED_CUDA_APPS = $(if $(filter 1,$(HAVE_CUDA)),$(CUDA_APPS),)
+ENABLED_SCX_APPS = $(if $(filter 1,$(HAVE_SCX)),$(SCX_APPS),)
+APPS = $(CORE_BPF_APPS) $(ENABLED_NVML_APPS) $(PTHREAD_APPS) $(ENABLED_CUDA_APPS) $(ENABLED_SCX_APPS) $(TOOL_APPS) # minimal minimal_legacy uprobe kprobe fentry usdt sockfilter tc ksyscall
+ALL_APPS = $(BPF_APPS) $(SCX_APPS) $(TOOL_APPS)
 
 CARGO ?= $(shell which cargo)
 ifeq ($(strip $(CARGO)),)
@@ -37,8 +58,21 @@ BZS_APPS :=
 else
 BZS_APPS := # profile
 APPS += $(BZS_APPS)
+ALL_APPS += $(BZS_APPS)
 # Required by libblazesym
 ALL_LDFLAGS += -lrt -ldl -lpthread -lm
+endif
+
+ifeq ($(HAVE_NVML),0)
+$(info Skipping NVML apps; set CUDA_INCLUDE_DIR/CUDA_STUB_DIR to enable: $(NVML_APPS))
+endif
+
+ifeq ($(HAVE_CUDA),0)
+$(info Skipping CUDA apps; set CUDA_INCLUDE_DIR/CUDA_STUB_DIR to enable: $(CUDA_APPS))
+endif
+
+ifeq ($(HAVE_SCX),0)
+$(info Skipping sched_ext apps; set SCX_INCLUDE_DIR to a kernel tools/sched_ext include tree and ensure $(SCX_VMLINUX) exists: $(SCX_APPS))
 endif
 
 # Get Clang's default includes on this system. We'll explicitly add these dirs
@@ -79,7 +113,7 @@ all: $(APPS)
 .PHONY: clean
 clean:
 	$(call msg,CLEAN)
-	$(Q)rm -rf $(OUTPUT) $(APPS)
+	$(Q)rm -rf $(OUTPUT) $(ALL_APPS)
 
 $(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
 	$(call msg,MKDIR,$@)
@@ -155,15 +189,6 @@ $(patsubst %,$(OUTPUT)/%.o,$(BZS_APPS)): $(LIBBLAZESYM_HEADER)
 
 $(BZS_APPS): $(LIBBLAZESYM_OBJ)
 
-# Apps that need NVML
-NVML_APPS = prefetch_adaptive_tree_iter prefetch_adaptive_sequential
-
-# Apps that need pthread
-PTHREAD_APPS = gpu_preempt_ctrl
-
-# Apps that need CUDA driver API + pthread
-CUDA_APPS = test_preempt_demo test_preempt_multi
-
 # Build application binary (exclude special apps from generic rule)
 $(filter-out $(NVML_APPS) $(PTHREAD_APPS) $(CUDA_APPS),$(APPS)): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
@@ -172,7 +197,7 @@ $(filter-out $(NVML_APPS) $(PTHREAD_APPS) $(CUDA_APPS),$(APPS)): %: $(OUTPUT)/%.
 # Special rule for apps with NVML
 $(NVML_APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
-	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -L/usr/local/cuda/lib64/stubs -lnvidia-ml -o $@
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -L$(CUDA_STUB_DIR) -lnvidia-ml -o $@
 
 # Special rule for apps with pthread
 $(PTHREAD_APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
@@ -182,7 +207,7 @@ $(PTHREAD_APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
 # Special rule for apps with CUDA + pthread
 $(CUDA_APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
-	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -lcuda -lpthread -o $@
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -L$(CUDA_STUB_DIR) -lcuda -lpthread -o $@
 
 # delete failed targets
 .DELETE_ON_ERROR:


### PR DESCRIPTION
## Summary
- add a dedicated CI workflow that builds the extension and kernel module on pull requests and pushes to master
- make the default extension build skip sched_ext, CUDA, and NVML targets when their host dependencies are not available
- harden the existing docker/publish workflows by refreshing apt metadata and removing the stale release asset path

## Verification
- `make build`
- `make build SCX_INCLUDE_DIR= CUDA_INCLUDE_DIR=/tmp/gpu_ext-missing-cuda/include CUDA_STUB_DIR=/tmp/gpu_ext-missing-cuda/stubs`
- `make -C kernel-module/nvidia-module modules -j2 SYSSRC="$(dpkg-query -W -f='${Package}\\n' 'linux-headers-[0-9]*-generic' 2>/dev/null | sort -V | tail -n1 | sed 's#^#/usr/src/#')"`
